### PR TITLE
NOJIRA Remove sbt-prompt (should be installed in ~/.sbt)

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,5 +7,3 @@ addSbtPlugin("com.rallyhealth" %% "rally-versioning" % "latest.integration") // 
 
 addSbtPlugin("com.rallyhealth" %% "rally-sbt-plugin" % "0.0.3")
 
-addSbtPlugin("com.scalapenos" % "sbt-prompt" % "0.2.1")
-


### PR DESCRIPTION
This should be done by developers locally https://wiki.audaxhealth.com/display/ENG/Development+Environment+Setup#DevelopmentEnvironmentSetup-SetupSBT 

@htmldoug @nicksovich @chrissalij-r @jeffmay 