### PR TITLE
Assimilate 1.2.0 to Rally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,22 @@
-# scalacheck-ops
-Common ScalaCheck implicits and helper methods
+<a href='https://travis-ci.org/jeffmay/scalacheck-ops'>
+  <img src='https://travis-ci.org/jeffmay/scalacheck-ops.svg' alt='Build Status' />
+</a>
+<a href='https://coveralls.io/github/jeffmay/scalacheck-ops?branch=master'>
+  <img src='https://coveralls.io/repos/jeffmay/scalacheck-ops/badge.svg?branch=master&service=github' alt='Coverage Status' />
+</a>
+<table>
+  <tr>
+    <th>scalacheck-ops</th>
+  </tr>
+  <tr>
+    <td>
+      <a href='https://bintray.com/jeffmay/maven/scalacheck-ops/_latestVersion'>
+        <img src='https://api.bintray.com/packages/jeffmay/maven/scalacheck-ops/images/download.svg'>
+      </a>
+    </td>
+  </tr>
+</table>
 
-[ ![Download](https://api.bintray.com/packages/jeffmay/maven/scalacheck-ops/images/download.svg) ](https://bintray.com/jeffmay/maven/scalacheck-ops/_latestVersion)
+# scalacheck-ops
+
+Common ScalaCheck implicits and helper methods

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,8 @@
-
 name := "scalacheck-ops"
-
 organization := "com.rallyhealth"
 
-crossScalaVersions := Seq("2.11.6", "2.10.4")
+scalaVersion := "2.11.7"
+crossScalaVersions := Seq("2.11.7", "2.10.4")
 
 scalacOptions := {
   // the deprecation:false flag is only supported by scala >= 2.11.3, but needed for scala >= 2.11.0 to avoid warnings
@@ -22,11 +21,11 @@ scalacOptions := {
   "-encoding", "UTF-8"
 )
 
-libraryDependencies := Seq(
+libraryDependencies ++= Seq(
   "org.joda" % "joda-convert" % "1.7",
   "joda-time" % "joda-time" % "2.8",
-  "org.scalacheck" %% "scalacheck" % "1.12.2",
-  "org.scalatest" %% "scalatest" % "2.2.4"
+  "org.scalacheck" %% "scalacheck" % "1.12.5",
+  "org.scalatest" %% "scalatest" % "2.2.6"
 )
 
 testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oF")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,6 @@ credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
 
 resolvers += Resolver.url("Rally Plugin Releases", url("https://artifacts.werally.in/artifactory/ivy-plugins-release"))(Resolver.ivyStylePatterns)
  
-addSbtPlugin("com.rallyhealth" %% "rally-versioning" % "latest.integration") // must appear before rally-sbt-plugin which depends on version.
-
-addSbtPlugin("com.rallyhealth" %% "rally-sbt-plugin" % "0.2.0")
+addSbtPlugin("com.rallyhealth" %% "rally-versioning" % "latest.release") // must appear before rally-sbt-plugin which depends on version.
+addSbtPlugin("com.rallyhealth" %% "rally-sbt-plugin" % "0.4.0")
 


### PR DESCRIPTION
@htmldoug @rcmurphy @patrick-bohan @chrissalij-r 

I was having issues getting version 1.1.0 - 1.1.3 on other machines. I presume it was because those versions were published to the wrong place. I'm updating the versioning plugin to use only the latest release to hopefully avoid this issue in the future.

Also, I upgraded Scala to 2.11.7 and upgraded libraries that I didn't think would break anything.